### PR TITLE
Fix sigstore action version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
           verbose: true
           print-hash: true
       - name: Sign published artifacts
-        uses: sigstore/gh-action-sigstore-python@v3
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
         with:
           inputs: ./dist/*.tar.gz ./dist/*.whl
           release-signing-artifacts: true


### PR DESCRIPTION
Running this action resulted in an error:

> Unable to resolve action `sigstore/gh-action-sigstore-python@v3`, unable to find version `v3`

The documentation for the action demonstrates a v3.0.0 version, so hopefully that is the fix although it is strange that the major version did not work: https://github.com/sigstore/gh-action-sigstore-python