### PR TITLE
Update publish workflow Python version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
       - published
 
 env:
-  DEFAULT_PYTHON: "3.12"
+  DEFAULT_PYTHON: "3.13"
 
 jobs:
   pypi-publish:


### PR DESCRIPTION
To circumvent error:

> The currently activated Python version 3.12.11 is not supported by the project (>=3.13).
> Trying to find and use a compatible version.
> Poetry was unable to find a compatible version. If you have one, you can explicitly use it via the "env use" command.